### PR TITLE
Feat: Add Rust Cargo deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,10 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,26 +1,21 @@
 [package]
 name = "tree-sitter-sourcepawn"
 description = "sourcepawn grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "sourcepawn"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/nilshelmig/tree-sitter-sourcepawn"
 edition = "2018"
 license = "MIT"
 
+include = ["bindings/rust/*", "grammar.js", "src/*", "LICENSE", "README.md"]
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20"
+tree-sitter = "~0.20.8"
 
 [build-dependencies]
-cc = "1.0"
+cc = "*"


### PR DESCRIPTION
This PR adds a workflow for publishing tree-sitter-sourcepawn to [Cargo](https://crates.io/).

All you have to do is set your Cargo token as a github SECRET named `CARGO_REGISTRY_TOKEN`.